### PR TITLE
fixed English language; corrected spelling mistakes

### DIFF
--- a/app/components/TokenBalance.vue
+++ b/app/components/TokenBalance.vue
@@ -48,7 +48,7 @@
         <div
           class="flex items-center hover:text-gray-900"
           @click="$emit('tokenClicked', bal)">
-          <div class="flex  font-bold cursor-pointer">
+          <div class="flex font-bold cursor-pointer">
             {{ roundDown(bal.balance*Math.pow(10, -1*bal.decimals), 4) | currency('', bal.symbol =='gZIL' ? 4:2) }}
           </div>
           <div

--- a/app/components/create/DownloadKeystoreFile.vue
+++ b/app/components/create/DownloadKeystoreFile.vue
@@ -33,7 +33,7 @@
         <ZLink
           to="/security/avoid-phishing-and-scams"
           external>
-          Simple tips to avoid Phishing and Scams
+          Simple tips to avoid phishing and scams
         </ZLink>
         and
         <ZLink
@@ -49,7 +49,7 @@
           type="default"
           rounded
           @click="$emit('close')">
-          Okay, I've succesfully saved my key.
+          I Saved My Key
         </z-button>
       </template>
     </DownloadWalletContainer>

--- a/app/components/create/DownloadMnemonicPhrase.vue
+++ b/app/components/create/DownloadMnemonicPhrase.vue
@@ -39,7 +39,7 @@
         <ZLink
           to="/security/avoid-phishing-and-scams"
           external>
-          Simple tips to avoid Phishing and Scams
+          Simple tips to avoid phishing and scams
         </ZLink>
         and
         <ZLink

--- a/app/components/index/AccessWallet.vue
+++ b/app/components/index/AccessWallet.vue
@@ -50,20 +50,20 @@
       <ZLink
         to="/security/avoid-phishing-and-scams"
         external>
-        Simple tips to avoid Phishing and Scams
+        Simple tips to avoid phishing and scams
       </ZLink>
       and
       <ZLink
         to="/getting-started/how-to-access-your-wallet"
         external>
-        How to access your Wallet
+        How to access your wallet
       </ZLink>
     </template>
     <template v-slot:warning>
       <p>
         <code>Zillet.io</code> does not hold your keys for you. We cannot access accounts,
         recover keys, reset passwords, nor reverse transactions. Protect your keys &
-        always check that you are on correct URL.
+        always check that you are on the correct URL.
         <span class="font-semibold">You are responsible for your security</span>.
       </p>
     </template>

--- a/app/components/index/AccessWalletKeystore.vue
+++ b/app/components/index/AccessWalletKeystore.vue
@@ -19,7 +19,7 @@
         class="w-full"
         rounded
         @click="unlock()">
-        Unlock wallet
+        Unlock Wallet
       </z-button>
     </div>
   </AccessWalletContainer>
@@ -68,7 +68,7 @@ export default {
           if (!this.checkEncryptedWallet(this.encryptedWallet)) {
             this.isFile = false;
             return this.$notify({
-              message: `Invalid file format, Please Select valid Keystore/wallet (JSON) File.`,
+              message: `Invalid file format, please select valid keystore/wallet (JSON) file.`,
               type: 'danger'
             });
           } else {
@@ -78,7 +78,7 @@ export default {
         reader.readAsText(file);
       } catch (error) {
         return this.$notify({
-          message: `Invalid file format, Please Select valid Keystore/wallet (JSON) File, ${error}`,
+          message: `Invalid file format, please select valid keystore/wallet (JSON) file, ${error}`,
           type: 'danger'
         });
       }
@@ -100,7 +100,7 @@ export default {
         });
       } catch (error) {
         return this.$notify({
-          message: `Failed to decrypt, Please check your password.`,
+          message: `Failed to decrypt, please check your password.`,
           type: 'danger'
         });
         this.loading = false;

--- a/app/components/index/AccessWalletLedger.vue
+++ b/app/components/index/AccessWalletLedger.vue
@@ -21,7 +21,7 @@
       <ZLink
         to="/troubleshooting/troubleshooting-ledger-issues"
         external>
-        Troubleshooting Ledger Issues
+        Troubleshooting Ledger issues
       </ZLink>
       and
       <ZLink

--- a/app/components/index/AccessWalletMnemonic.vue
+++ b/app/components/index/AccessWalletMnemonic.vue
@@ -19,7 +19,7 @@
     <z-textarea
       v-model="mnemonicPhrase"
       :valid="isMnemonicValid(mnemonicPhrase)"
-      :placeholder="selectedType ===2 ? `Enter your 24 character ledger Mnemonic phrase here`: `Enter your Mnemonic phrase here`"
+      :placeholder="selectedType ===2 ? `Enter your 24 character ledger mnemonic phrase here`: `Enter your mnemonic phrase here`"
       class="mnemonic-textarea"
     />
     <div v-if="selectedType==1">
@@ -31,8 +31,8 @@
       <z-alert
         type="warning"
         class="my-2">
-        This is not the password you set in the Moonlet or ZilPay wallet, 
-        In most of the cases you need default method.
+        This is not the password you set in the Moonlet or ZilPay wallet; 
+        in most of the cases you need default method.
       </z-alert>
     </div>
     <div v-if="selectedType==2">
@@ -41,7 +41,7 @@
         placeholder="Index"
         :hide="false"
         number
-        label="Index of ledger wallet (Default = 0)"
+        label="Index of ledger wallet (default = 0)"
       />
     </div>
     <z-button
@@ -49,7 +49,7 @@
       rounded
       class="w-full"
       @click="loadWallet()">
-      Load wallet
+      Load Wallet
     </z-button>
   </AccessWalletContainer>
 </template>

--- a/app/components/index/AccessWalletMoonlet.vue
+++ b/app/components/index/AccessWalletMoonlet.vue
@@ -21,7 +21,7 @@
     <p
       v-if="notFound"
       align="left">
-      Moonlet extension not found. Please check that extension is installed or
+      Moonlet extension not found. Please check that the extension is installed or
       download the extension from the link below.
       <z-button
         class="w-full my-4"
@@ -37,13 +37,13 @@
     <p
       v-if="permissionNotGranted"
       align="left">
-      You did not grant access on this page for Moonlet Wallet.
-      You have to let Moonlet Wallet to access this page in order to continue.
+      You did not grant Moonlet Wallet access to this page.
+      Moonlet Wallet needs access to this page in order to continue.
       <z-button
         class="w-full my-4"
         rounded 
         @click="connect()">
-        Grant permission
+        Grant Permission
       </z-button>
     </p>
   </AccessWalletContainer>
@@ -119,7 +119,7 @@ export default {
             console.log(this.permissionNotGranted);
           default:
             this.$notify({
-              message: `There was an error while loading moonlet wallet instance.`,
+              message: `There was an error while loading Moonlet Wallet instance.`,
               type: 'danger'
             });
         }

--- a/app/components/index/AccessWalletMoonlet.vue
+++ b/app/components/index/AccessWalletMoonlet.vue
@@ -31,7 +31,7 @@
         <a
           href="https://moonlet.xyz/"
           target="_blank"
-          rel="noopener norefrer nofollow">Download Extension</a>
+          rel="noopener noreferrer nofollow">Download Extension</a>
       </z-button>
     </p>
     <p

--- a/app/components/index/AccessWalletPrivateKey.vue
+++ b/app/components/index/AccessWalletPrivateKey.vue
@@ -14,7 +14,7 @@
       rounded
       class="w-full"
       @click="validateKey()">
-      Load wallet
+      Load Wallet
     </z-button>
   </AccessWalletContainer>
 </template>

--- a/app/components/index/AccessWalletZilpay.vue
+++ b/app/components/index/AccessWalletZilpay.vue
@@ -17,7 +17,7 @@
     <p
       v-if="notFound"
       align="left">
-      Zilpay extension not found. Please check that extension is installed or
+      Zilpay extension not found. Please check that the extension is installed or
       download the extension from the link below.
       <z-button
         class="w-full my-4"
@@ -68,7 +68,7 @@ export default {
           const { defaultAccount } = zilPay.wallet;
           if (!defaultAccount) {
             return this.$notify({
-              message: `Kindly unlock your account ZilPay account first`,
+              message: `Kindly unlock your ZilPay account first`,
               type: 'danger'
             });
           }
@@ -76,7 +76,7 @@ export default {
             if (this.Account.address != account.base16) {
               this.save(account.base16);
               this.$notify({
-                message: `New account loaded succesfully`,
+                message: `New account loaded successfully`,
                 type: 'success'
               });
             }
@@ -112,7 +112,7 @@ export default {
       } else {
         this.notFound = true;
         this.$notify({
-          message: `Zilpay extension is not installed.`,
+          message: `ZilPay extension is not installed.`,
           type: 'danger'
         });
         console.warn('ZilPay not installed');

--- a/app/components/index/AccessWalletZilpay.vue
+++ b/app/components/index/AccessWalletZilpay.vue
@@ -27,7 +27,7 @@
         <a
           href="https://zilpay.xyz/"
           target="_blank"
-          rel="noopener norefrer nofollow">Download Extension</a>
+          rel="noopener noreferrer nofollow">Download Extension</a>
       </z-button>
     </p>
   </AccessWalletContainer>

--- a/app/components/ledger/AccountIndex.vue
+++ b/app/components/ledger/AccountIndex.vue
@@ -4,7 +4,7 @@
     custom-class="p-8"
     @close="$emit('close')">
     <h3 class="font-semibold text-xl mb-8 text-gray-800">
-      Select Acount
+      Select Account
     </h3>
     <z-table
       :data="accounts"

--- a/app/components/send/Broadcasted.vue
+++ b/app/components/send/Broadcasted.vue
@@ -12,7 +12,7 @@
       </span>
       <div
         class="mt-4 mt-2 text-sm italic">
-        * Your balance will be updated after transaction got confirmed.
+        * Your balance will be updated after the transaction got confirmed.
       </div>
       <div class="flex flex-row -mx-2">
         <div class="w-1/2 px-2">

--- a/app/components/staking/RewardClaim.vue
+++ b/app/components/staking/RewardClaim.vue
@@ -9,8 +9,8 @@
         Claim <b>ZIL</b> reward
       </div>
       <p class=" text-left my-4">
-        You have delegated your ZIL to  {{ myStakes.length }} delegator. 
-        You need to claim your reward Individually.
+        You have delegated your ZIL to {{ myStakes.length }} delegator{{ myStakes.length == 1 ? '' : 's' }}. 
+        You need to claim your reward individually.
       </p>
       <z-table
         class="w-full"
@@ -32,7 +32,7 @@
             class="font-semibold"
             field="myReward">
             {{ scope.row.myReward*Math.pow(10, -12) | currency('', 4) }} +               
-            {{ scope.row.myReward*Math.pow(10,-15) | currency('', 4) }} 
+            {{ scope.row.myReward*Math.pow(10, -15) | currency('', 4) }} 
           </z-table-column>
           <z-table-column
             label="Action"

--- a/app/components/staking/Stake.vue
+++ b/app/components/staking/Stake.vue
@@ -17,7 +17,7 @@
           class=" text-sm cursor-pointer"
           @click="amount=(avlAmount > 0 ? avlAmount : 0)"
         >
-          <b class="text-teal-600">{{ avlAmount > 0 ? avlAmount : 0 }}</b>  ZIL Availble 
+          <b class="text-teal-600">{{ avlAmount > 0 ? avlAmount : 0 }}</b>  ZIL available 
         </div>
       </div>
       <div class="flex flex-row">

--- a/app/components/staking/TransferStake.vue
+++ b/app/components/staking/TransferStake.vue
@@ -29,7 +29,7 @@
             </p>
             <p class="text-gray-800 pr-6 text-sm">
               <b class="text-base">{{ fromNode.amount*Math.pow(10, -12) | currency('', 2) }}</b> 
-              ZIL Staked
+              ZIL staked
             </p>
           </div>
           <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
@@ -95,7 +95,7 @@
             </p>
             <p class="text-gray-800 pr-6 text-sm">
               <b class="text-base">{{ toNode.commision | currency('', 2) }} %</b>
-              (Commission rate )
+              (Commission rate)
             </p>
           </div>
           <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
@@ -167,12 +167,12 @@
         </div>
       </div>
       <p class="italic text-left flex flex-row flex-wrap text-sm mt-2">
-        * Redelegate to other SSN is instant.
+        * Redelegation to other SSN is instant.
         <ZLink
           to="/staking-on-zillet#what-are-the-benefits-of-delegating"
           class="text-left"
           external>
-          Who should you re-delegate your ZILs to?
+          Who should you redelegate your ZILs to?
         </ZLink>
       </p>
       <div

--- a/app/components/staking/Unstake.vue
+++ b/app/components/staking/Unstake.vue
@@ -18,7 +18,7 @@
             class=" text-sm cursor-pointer"
             @click="fillMax"
           >
-            <b class="text-teal-600">{{ Number(selectedSeedNode.amount*Math.pow(10,-12)).toFixed(4) }}</b> ZIL  Available   
+            <b class="text-teal-600">{{ Number(selectedSeedNode.amount*Math.pow(10,-12)).toFixed(4) }}</b> ZIL available   
           </div>
         </div>
         <div class="flex flex-row">
@@ -41,7 +41,7 @@
 
       <div v-if="myStakes.length > 1">
         <p class=" text-left my-2">
-          It looks like you have delegted ZILs to {{ myStakes.length }} different seed nodes. Please select a seed node where you
+          It looks like you have delegated ZILs to {{ myStakes.length }} different seed nodes. Please select a seed node where you
           want to undelegate your amount. 
         </p>
         <div class="flex flex-row items-center justify-between">
@@ -114,8 +114,8 @@
         class="bg-gray-100 text-gray-700 rounded my-4 p-2 px-4  text-left flex flex-row items-center">
         <i class="eva eva-info-outline text-xl mr-4" />
         <div>
-          After Unstake you have to wait for at least <strong>{{ bnumReq }}</strong> ({{ bnumReq/12000 }} Week) confirmation in 
-          order to make the withdrawal
+          After Unstake you have to wait for at least <strong>{{ bnumReq }}</strong>confirmations ({{ bnumReq/12000 }} week period) in 
+          order to make the withdrawal.
         </div>
       </div>
       <div

--- a/app/layouts/partials/Onboarding.vue
+++ b/app/layouts/partials/Onboarding.vue
@@ -156,7 +156,7 @@ export default {
           text: `Thanks for reading through our introduction! Now you're ready to
           dive in. If you want to know more, please head to our
           <a href="//support.zillet.io" class="text-primary"
-          target="_blank" rel="noreferer nofollow"> Help Center</a>. We are
+          target="_blank" rel="noreferrer nofollow"> Help Center</a>. We are
           here to help you have the most secure and most convenient experience possible!`,
           image: 'congratulations.svg'
         }

--- a/app/pages/create.vue
+++ b/app/pages/create.vue
@@ -51,7 +51,7 @@
           <p
             v-if="walletType==='json'"
             class="text-gray-700 -mt-1 text-left text-sm italic text-left">
-            Password should be at least 8 characters long
+            Password should be at least 8 characters long.
           </p>
           <p
             v-else
@@ -72,7 +72,7 @@
             v-if="walletType==='mnemonic'"
             to="/security/mnemonic-phrase-password"
             external>
-            Should I include password in Mnemonic phrase
+            Should I include password in Mnemonic phrase?
           </ZLink>
           <span v-if="walletType==='mnemonic'">
             and
@@ -80,7 +80,7 @@
           <ZLink
             to="/getting-started/how-to-create-a-wallet"
             external>
-            How to Create a Wallet
+            How to create a Wallet
           </ZLink>
         </template>
         <template v-slot:warning>

--- a/app/pages/info.vue
+++ b/app/pages/info.vue
@@ -153,7 +153,7 @@
 
             rel="noopener noreferrer">
             <i class="eva eva-github mr-1" />
-            Github
+            GitHub
           </a>
         </div>
       </div>
@@ -195,7 +195,7 @@
             placeholder="Do not forget this password" />
           <p
             class="text-gray-700 -mt-1 text-left text-sm italic text-left">
-            Password should be atleast 8 chracter long
+            Password should be at least 8 characters long.
           </p>
         </div>
         <div class="flex items-center justify-between -mx-3">

--- a/app/pages/send.vue
+++ b/app/pages/send.vue
@@ -40,7 +40,7 @@
             <div
               v-else
               class="text-sm italic">
-              Unfortunately, We are not able to resolve this domain, Kindly verify the domain name. 
+              Unfortunately, we are not able to resolve this domain. Kindly verify the domain name. 
             </div>
           </div>
         </div>
@@ -347,7 +347,7 @@
         </div>
         <p class="italic text-left text-sm mt-4">
           * Please carefully check the transaction details. Once broadcasted to the
-          network transaction <b>can not be revert back</b>
+          network, the transaction <b>cannot be reversed</b>.
         </p>
         <div class="flex flex-row -mx-2">
           <div class="w-1/3 px-2">
@@ -366,7 +366,7 @@
               class="mt-8 w-full"
               :loading="loading"
               @click="hasChecked=true;createTxn()">
-              Send this transaction.
+              Send Transaction
             </z-button>
           </div>
         </div>
@@ -797,7 +797,7 @@ export default {
         } catch (error) {
           this.loading = false;
           return this.$notify({
-            message: `Something went wrong${JSON.stringify(error)}`,
+            message: `Something went wrong ${JSON.stringify(error)}`,
             type: 'danger'
           });
         }
@@ -896,7 +896,7 @@ export default {
       }
       if (!this.normaliseAddress(this.transaction.address)) {
         return this.$notify({
-          message: `Address format is invalid`,
+          message: `Address format is invalid.`,
           type: 'danger'
         });
       }
@@ -916,7 +916,7 @@ export default {
         );
         if (this.transaction.amount > tBal) {
           return this.$notify({
-            message: `Amount can not be greater than balance`,
+            message: `Amount can not be greater than your balance.`,
             type: 'danger'
           });
         }
@@ -937,7 +937,7 @@ export default {
       if (total.gt(balance)) {
         this.loading = false;
         return this.$notify({
-          message: `Amount+Fee can not be greater than your balance`,
+          message: `Amount+Fee can not be greater than your balance.`,
           type: 'danger'
         });
       }
@@ -948,7 +948,7 @@ export default {
         this.loading = false;
 
         return this.$notify({
-          message: `Gas price is not sufficient`,
+          message: `Gas price is not sufficient.`,
           type: 'danger'
         });
       }
@@ -1069,7 +1069,7 @@ export default {
           this.transaction.amount = 0;
           this.usdAmount = 0;
           this.$notify({
-            message: 'Your balance seems low',
+            message: 'Your balance seems low.',
             type: 'danger'
           });
         }

--- a/app/pages/staking.vue
+++ b/app/pages/staking.vue
@@ -51,7 +51,7 @@
             {{ bnumReq }}
           </div>
           <div class="">
-            Min block confirmation needed
+            Min block confirmations needed
           </div>
         </div>
         <div class="flex flex-row items-center justify-between">
@@ -122,7 +122,7 @@
           </div>
           
           <div class="">
-            Unclaimed Reward.
+            Unclaimed reward
           </div>
           <div class="flex flex-row items-center justify-between">
             <z-button
@@ -668,7 +668,7 @@ export default {
       const nonce = this.Account.nonce + 1;
       console.log(this.Account.balance * Math.pow(10, -12));
       if (this.Account.balance * Math.pow(10, -12) < 30) {
-        throw Error('Account balance is low, Balance should be atleast 30 ZIL');
+        throw Error('Account balance is low, balance should be at least 30 ZIL.');
       }
       let txParams = {
         version: VERSION,
@@ -757,7 +757,7 @@ export default {
       } catch (error) {
         this.loading = false;
         return this.$notify({
-          message: `Something went wrong${JSON.stringify(error)}`,
+          message: `Something went wrong ${JSON.stringify(error)}`,
           type: 'danger'
         });
       }
@@ -783,8 +783,8 @@ export default {
       this.loading = true;
       let actualAmount = units.toQa(amount, units.Units.Zil);
       if (parseInt(actualAmount.toString()) < parseInt(this.minStake)) {
-        this.errorMsg = `Stake amount should be greater then ${this.minStake *
-          Math.pow(10, -12)}`;
+        this.errorMsg = `Stake amount should be greater than ${this.minStake *
+          Math.pow(10, -12)}.`;
         this.loading = false;
         return this.$notify({
           message: this.errorMsg,
@@ -841,7 +841,7 @@ export default {
         if (new BN(amountInQa).gt(new BN(ssn.amount))) {
           this.loading = false;
           this.errorMsg =
-            'Invalid Transfer Amount You only have ' +
+            'Invalid transfer amount; you only have ' +
             amount +
             ' ZIL to transfer.';
           this.$notify({
@@ -852,7 +852,7 @@ export default {
         } else if (leftOverQa > 0 && leftOverQa <= this.minStake) {
           this.loading = false;
           this.errorMsg =
-            'Invalid Transfer Amount please leave at least ' +
+            'Invalid transfer amount; please leave at least ' +
             this.minStake * Math.pow(10, -12) +
             ' ZIL (min. stake amount) or transfer ALL.';
           this.$notify({
@@ -1020,7 +1020,7 @@ export default {
       }
     },
     async transfer(fromNode, toNode, amount) {
-      console.log(`Transfaring staked...`, amount);
+      console.log(`Transfering staked...`, amount);
       this.actionType = 'transfer';
       this.loading = true;
       try {

--- a/app/pages/tokens.vue
+++ b/app/pages/tokens.vue
@@ -124,12 +124,12 @@
         </h3>
         <div class="text-left">
           <p class="text-lg mb-4">
-            You have non zero balance in your wallet. <br>
+            You have non-zero balance in your wallet. <br>
             Are you sure you want to remove {{ selectedToken.symbol }} from your token list?
           </p>
           <span class="text-sm italic">
-            * Please note that this action will only remove token from 
-            the wallet UI. you'll still have the tokens in your wallet.
+            * Please note that this action will only remove tokens from 
+            the wallet UI. You will still have the tokens in your wallet.
           </span>
         </div>
         <div class="flex items-center justify-between -mx-3 mt-4">

--- a/app/pages/transactions.vue
+++ b/app/pages/transactions.vue
@@ -426,7 +426,7 @@ export default {
     onCopy(e) {
       this.$notify({
         icon: 'eva eva-checkmark-circle-outline',
-        message: `Address copied successfully `,
+        message: `Address copied successfully`,
         type: 'success'
       });
     },


### PR DESCRIPTION
This commit is fixing language-related mistakes and improves consistency in upper/lower case use.

In ` app/components/index/AccessWalletMoonlet.vue` there might be a problem regarding the current language on granting access to either Moonlet or the page. As I do not use Moonlet, I am not sure which way the granting is supposed to work. Presently, the language assumes that the Moonlet Wallet needs access to the page, not the page requiring access to Moonlet Wallet. This might be the wrong way around...